### PR TITLE
Remove duplicate shadowing gic_dregs from gic.c

### DIFF
--- a/src/07_interrupts/src/gic.c
+++ b/src/07_interrupts/src/gic.c
@@ -10,7 +10,6 @@ void gic_init(void) {
     WRITE32(gic_ifregs->CCPMR, 0xFFFFu); /* Enable all interrupt priorities */
     WRITE32(gic_ifregs->CCTLR, CCTRL_ENABLE); /* Enable interrupt forwarding to this CPU */
 
-    gic_distributor_registers* gic_dregs = (gic_distributor_registers*)GIC_DIST_BASE;
     WRITE32(gic_dregs->DCTLR, DCTRL_ENABLE); /* Enable the interrupt distributor */
 }
 

--- a/src/08_scheduler/src/gic.c
+++ b/src/08_scheduler/src/gic.c
@@ -10,7 +10,6 @@ void gic_init(void) {
     WRITE32(gic_ifregs->CCPMR, 0xFFFFu); /* Enable all interrupt priorities */
     WRITE32(gic_ifregs->CCTLR, CCTRL_ENABLE); /* Enable interrupt forwarding to this CPU */
 
-    gic_distributor_registers* gic_dregs = (gic_distributor_registers*)GIC_DIST_BASE;
     WRITE32(gic_dregs->DCTLR, DCTRL_ENABLE); /* Enable the interrupt distributor */
 }
 

--- a/src/09_context_switch/src/gic.c
+++ b/src/09_context_switch/src/gic.c
@@ -10,7 +10,6 @@ void gic_init(void) {
     WRITE32(gic_ifregs->CCPMR, 0xFFFFu); /* Enable all interrupt priorities */
     WRITE32(gic_ifregs->CCTLR, CCTRL_ENABLE); /* Enable interrupt forwarding to this CPU */
 
-    gic_distributor_registers* gic_dregs = (gic_distributor_registers*)GIC_DIST_BASE;
     WRITE32(gic_dregs->DCTLR, DCTRL_ENABLE); /* Enable the interrupt distributor */
 }
 


### PR DESCRIPTION
Removed local duplicate of static gic_dregs from gic_init().